### PR TITLE
Fix error with memory allocation

### DIFF
--- a/pgsp_json_text.c
+++ b/pgsp_json_text.c
@@ -1014,7 +1014,9 @@ pgsp_json_textize(char *json)
 	init_parser_context(&ctx, PGSP_JSON_TEXTIZE, json, NULL, 0);
 
 	ctx.nodevals = (node_vals*)palloc0(sizeof(node_vals));
-
+	if (ctx.nodevals == NULL)
+		return NULL;
+		
 	sem.semstate = (void*)&ctx;
 	sem.object_start       = json_text_objstart;
 	sem.object_end         = json_text_objend;


### PR DESCRIPTION
1. Есть места, где не присвоили NULL
2. Есть места, где не проверили на NULL
3. Есть ненужный указатель
4. В pgsp_json_text.c не проверяют, успешно ли выделели память в куче.