### PR TITLE
Add two counters for the plan estimation error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # pg_stat_plan/Makefile
 
 MODULES = pg_store_plans
-STOREPLANSVER = 1.9
+STOREPLANSVER = 1.9.1
 
 MODULE_big = pg_store_plans
-OBJS = pg_store_plans.o pgsp_json.o pgsp_json_text.o pgsp_explain.o
+OBJS = pg_store_plans.o pgsp_json.o pgsp_json_text.o pgsp_explain.o plan_error.o
 
 EXTENSION = pg_store_plans
 
@@ -13,7 +13,7 @@ PG_VERSION := $(shell pg_config --version | sed "s/^PostgreSQL //" | sed "s/\.[0
 DATA = pg_store_plans--1.6.sql pg_store_plans--1.6--1.6.1.sql \
        pg_store_plans--1.6.1--1.6.2.sql pg_store_plans--1.6.2--1.6.3.sql \
        pg_store_plans--1.6.3--1.6.4.sql pg_store_plans--1.6.4--1.8.sql pg_store_plans--1.8--1.8.1.sql \
-	   pg_store_plans--1.8.1--1.9.sql
+	   pg_store_plans--1.8.1--1.9.sql pg_store_plans--1.9--1.9.1.sql
 
 REGRESS = convert store
 REGRESS_OPTS = --temp-config=regress.conf
@@ -53,7 +53,7 @@ TARSOURCES = Makefile *.c  *.h \
 	docs/* expected/*.out sql/*.sql \
 
 ifneq ($(shell uname), SunOS)
-LDFLAGS+=-Wl,--build-id
+LDFLAGS+=-Wl
 endif
 
 ## These entries need running server

--- a/pg_store_plans--1.9--1.9.1.sql
+++ b/pg_store_plans--1.9--1.9.1.sql
@@ -1,0 +1,55 @@
+/* pg_store_plans/pg_store_plans--1.9--1.9.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pg_store_plans" to load this file. \quit
+
+DROP VIEW IF EXISTS pg_store_plans;
+DROP FUNCTION IF EXISTS pg_store_plans();
+
+CREATE FUNCTION pg_store_plans(
+    OUT userid oid,
+    OUT dbid oid,
+    OUT queryid int8,
+    OUT planid int8,
+    OUT plan text,
+	OUT plan_error float8,
+	OUT plan_error2 float8,
+    OUT calls int8,
+    OUT total_time float8,
+    OUT min_time float8,
+    OUT max_time float8,
+    OUT mean_time float8,
+    OUT stddev_time float8,
+    OUT rows int8,
+    OUT shared_blks_hit int8,
+    OUT shared_blks_read int8,
+    OUT shared_blks_dirtied int8,
+    OUT shared_blks_written int8,
+    OUT local_blks_hit int8,
+    OUT local_blks_read int8,
+    OUT local_blks_dirtied int8,
+    OUT local_blks_written int8,
+    OUT temp_blks_read int8,
+    OUT temp_blks_written int8,
+    OUT shared_blk_read_time float8,
+    OUT shared_blk_write_time float8,
+    OUT local_blk_read_time float8,
+    OUT local_blk_write_time float8,
+    OUT temp_blk_read_time float8,
+    OUT temp_blk_write_time float8,
+    OUT first_call timestamptz,
+    OUT last_call timestamptz
+)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_store_plans_1_9_1'
+LANGUAGE C
+VOLATILE PARALLEL SAFE;
+
+-- Register a view on the function for ease of use.
+CREATE OR REPLACE VIEW pg_store_plans AS
+  SELECT * FROM pg_store_plans();
+
+GRANT SELECT ON pg_store_plans TO PUBLIC;
+
+-- Don't want this to be available to non-superusers.
+REVOKE ALL ON FUNCTION pg_store_plans_reset() FROM PUBLIC;

--- a/pg_store_plans.control
+++ b/pg_store_plans.control
@@ -1,5 +1,5 @@
 # pg_store_plans extension
 comment = 'track plan statistics of all SQL statements executed'
-default_version = '1.9'
+default_version = '1.9.1'
 module_pathname = '$libdir/pg_store_plans'
 relocatable = true

--- a/plan_error.c
+++ b/plan_error.c
@@ -1,0 +1,176 @@
+/*-------------------------------------------------------------------------
+ *
+ * plan_error.c
+ *		Pass through a query plan and calculate estimation error.
+ *
+ * Copyright (c) 2024-2025 Andrei Lepikhov
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "nodes/execnodes.h"
+#include "optimizer/optimizer.h"
+
+#include "plan_error.h"
+
+static bool
+prediction_walker(PlanState *pstate, void *context)
+{
+	double					plan_rows,
+							real_rows = 0;
+	PlanEstimatorContext   *ctx = (PlanEstimatorContext *) context;
+	double					nloops;
+	int						tmp_counter;
+	double					relative_time;
+
+	/* At first, increment the counter */
+	ctx->counter++;
+
+	tmp_counter = ctx->counter;
+	planstate_tree_walker(pstate, prediction_walker, context);
+
+	/*
+	 * Finish the node before an analysis. And only after that we can touch any
+	 * instrument fields.
+	 */
+	InstrEndLoop(pstate->instrument);
+	nloops = pstate->instrument->nloops;
+
+
+	if (nloops <= 0.0 || pstate->instrument->total == 0.0)
+		/*
+		 * Skip 'never executed' case or "0-Tuple situation" and the case of
+		 * manual switching off of the timing instrumentation
+		 */
+		return false;
+
+	/*
+	 * Calculate number of rows predicted by the optimizer and really passed
+	 * through the node. This simplistic code becomes a bit tricky in the case
+	 * of parallel workers.
+	 */
+	if (pstate->worker_instrument)
+	{
+		double	wnloops = 0.;
+		double	wntuples = 0.;
+		double	divisor = pstate->worker_instrument->num_workers;
+		double	leader_contribution;
+		int i;
+
+		/* XXX: Copy-pasted from the get_parallel_divisor() */
+		if (parallel_leader_participation)
+		{
+			leader_contribution = 1.0 - (0.3 * divisor);
+			if (leader_contribution > 0)
+				divisor += leader_contribution;
+		}
+
+		plan_rows = pstate->plan->plan_rows * divisor;
+
+		for (i = 0; i < pstate->worker_instrument->num_workers; i++)
+		{
+			double t = pstate->worker_instrument->instrument[i].ntuples;
+			double l = pstate->worker_instrument->instrument[i].nloops;
+
+			if (l <= 0.0)
+			{
+				/*
+				 * Worker could start but not to process any tuples just because
+				 * of laziness. Skip such a node.
+				 */
+				continue;
+			}
+
+			wntuples += t;
+
+			/* In leaf nodes we should get into account filtered tuples */
+			if (tmp_counter == ctx->counter)
+				wntuples += pstate->worker_instrument->instrument[i].nfiltered1 +
+							pstate->worker_instrument->instrument[i].nfiltered2 +
+							pstate->instrument->ntuples2;
+
+			wnloops += l;
+			real_rows += t/l;
+		}
+
+		Assert(nloops >= wnloops);
+
+		/* Calculate the part of job have made by the main process */
+		if (nloops - wnloops > 0.0)
+		{
+			double	ntuples = pstate->instrument->ntuples;
+
+			/* In leaf nodes we should get into account filtered tuples */
+			if (tmp_counter == ctx->counter)
+				ntuples += (pstate->instrument->nfiltered1 +
+												pstate->instrument->nfiltered2 +
+												pstate->instrument->ntuples2);
+
+			Assert(ntuples >= wntuples);
+			real_rows += (ntuples - wntuples) / (nloops - wnloops);
+		}
+	}
+	else
+	{
+		plan_rows = pstate->plan->plan_rows;
+		real_rows = pstate->instrument->ntuples / nloops;
+
+		/* In leaf nodes we should get into account filtered tuples */
+		if (tmp_counter == ctx->counter)
+			real_rows += (pstate->instrument->nfiltered1 +
+									pstate->instrument->nfiltered2 +
+									pstate->instrument->ntuples2) / nloops;
+	}
+
+	plan_rows = clamp_row_est(plan_rows);
+	real_rows = clamp_row_est(real_rows);
+
+	/*
+	 * Now, we can calculate a value of the estimation relative error has made
+	 * by the optimizer.
+	 */
+	Assert(pstate->instrument->total > 0.0);
+
+	ctx->error += fabs(log(real_rows / plan_rows));
+	ctx->nnodes++;
+
+	relative_time = pstate->instrument->total / pstate->instrument->nloops / ctx->totaltime;
+	ctx->time_weighted_error += fabs(log(real_rows / plan_rows)) * relative_time;
+
+	return false;
+}
+
+/*
+ * Assess planning quality.
+ *
+ * Compare execution state and the plan. Passing through the each node, compute
+ * different types of relative error and save them in the context. Return
+ * the estimated error that is proved as helpful in many cases.
+ */
+double
+plan_error(PlanState *pstate, double totaltime, PlanEstimatorContext *ctx)
+{
+	ctx->totaltime = totaltime;
+	ctx->nnodes = 0;
+	ctx->counter = 0;
+	ctx->error = -1.;
+	ctx->time_weighted_error = -1.;
+
+	if (pstate->instrument == NULL)
+		/* Guard against manipulations with analyse settings */
+		return -1.;
+
+	Assert(totaltime > 0.);
+	(void) prediction_walker(pstate, (void *) ctx);
+
+	ctx->error = (ctx->nnodes > 0) ? (ctx->error / ctx->nnodes) : -1.0;
+	ctx->time_weighted_error = (ctx->nnodes > 0) ?
+								(ctx->time_weighted_error / ctx->nnodes) : -1.0;
+
+	return ctx->error;
+}

--- a/plan_error.h
+++ b/plan_error.h
@@ -1,0 +1,29 @@
+#ifndef PLAN_ERROR_H
+#define PLAN_ERROR_H
+
+#include "nodes/nodeFuncs.h"
+
+/*
+ * Data structure used for error estimation as well as for statistics gathering.
+ */
+typedef struct PlanEstimatorContext
+{
+	double	totaltime;
+
+	/* Number of nodes assessed */
+	int		nnodes;
+
+	/*
+	 * Total number of nodes in the plan. Originally, used to detect leaf nodes.
+	 * Now, it is a part of statistics.
+	 */
+	int 	counter;
+
+	/* Different types of planning error may be placed here */
+	double	error;
+	double	time_weighted_error;
+} PlanEstimatorContext;
+
+#endif /* PLAN_ERROR_H */
+
+double plan_error(PlanState *pstate, double totaltime, PlanEstimatorContext *ctx);


### PR DESCRIPTION
Introduce two new tracking parameters: plan_error and plan_error2. The first one tracks the average non-weighted planning error, while the second normalises this estimate at each node using the time-per-tuple factor.

The specific labels for these parameters in the UI are a subject for discussion.

TODO: There are some tests (at least trivial ones) that are needed.